### PR TITLE
DialogSwapper: fix broken ipairs iteration

### DIFF
--- a/macros/Flux.DialogSwapper.moon
+++ b/macros/Flux.DialogSwapper.moon
@@ -162,7 +162,7 @@ replace = (subs) ->
                 line.comment = not line.comment
 
             if validateLine style
-                for pair in ipairs swapPatterns
+                for pair in *swapPatterns
                     line.text = line.text\gsub pair[1], pair[2]
             subs[lineNumber] = line
 


### PR DESCRIPTION
Using moonscript's built-in `*table` iteration
alternatively it would be `i, pair in ipairs(...)`